### PR TITLE
Add issue performer assignation 

### DIFF
--- a/app/controllers/time_trackers_controller.rb
+++ b/app/controllers/time_trackers_controller.rb
@@ -18,6 +18,11 @@ class TimeTrackersController < ApplicationController
             @time_tracker = TimeTracker.new({ :issue_id => @issue.id })
 
             if @time_tracker.save
+                @issue.assigned_to_id = User.current.id
+                if @issue.save
+                else
+                    flash[:error] = l(:auto_change_issue_assigned_to_id)
+                end
                 apply_status_transition(@issue) unless Setting.plugin_redmine_time_tracker['status_transitions'] == nil
                 render_menu
             else

--- a/app/controllers/time_trackers_controller.rb
+++ b/app/controllers/time_trackers_controller.rb
@@ -18,11 +18,15 @@ class TimeTrackersController < ApplicationController
             @time_tracker = TimeTracker.new({ :issue_id => @issue.id })
 
             if @time_tracker.save
-                @issue.assigned_to_id = User.current.id
-                if @issue.save
-                else
-                    flash[:error] = l(:auto_change_issue_assigned_to_id)
+                if Setting.plugin_redmine_time_tracker['issue_assigned_to_id']
+                    if @issue.assigned_to_id.nil?
+                        @issue.assigned_to_id = User.current.id
+                        if not @issue.save
+                            flash[:error] = l(:auto_change_issue_assigned_to_id)
+                        end
+                    end
                 end
+
                 apply_status_transition(@issue) unless Setting.plugin_redmine_time_tracker['status_transitions'] == nil
                 render_menu
             else

--- a/app/views/settings/_time_tracker.html.erb
+++ b/app/views/settings/_time_tracker.html.erb
@@ -15,6 +15,11 @@
         <%= check_box_tag 'settings[redirect_to_issue]', 'true', @settings['redirect_to_issue'], { :size => 4 } %>
         <%= l(:time_tracker_redirect_to_issue_help) %>
     </p>
+    <p>
+        <%= label_tag 'settings[issue_assigned_to_id]', l(:settings_label_issue_assigned_to_id) %>
+        <%= check_box_tag 'settings[issue_assigned_to_id]', 'true', @settings['issue_assigned_to_id'], { :size => 4 } %>
+        <%= l(:settings_label_issue_assigned_to_id_help) %>
+    </p>
 </div>
 
 <h3><%= l(:time_tracker_settings_transition_title) %></h3>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 # English strings go here for Rails i18n
 en:
   auto_change_issue_assigned_to_id: "Fail to change assigned user to the issue"
+  auto_change_already_issue_assigned_to_id: "A user to the issue is already assigned"
   list_time_trackers: "list"
   no_time_tracker: "No time tracker"
   no_time_tracker_running: "No time tracker is running"
@@ -29,6 +30,8 @@ en:
   time_tracker_refresh_rate: "Refresh rate"
   time_tracker_redirect_to_issue_help: "If enabled, the stop button opens the issue. Otherwise a new time entry is opened."
   time_tracker_redirect_to_issue: "Redirect to issue"
+  settings_label_issue_assigned_to_id: "Assign performer"
+  settings_label_issue_assigned_to_id_help: "If enabled and the issue does not have a performer, the issue performer will be assigned current user. If the issue has a performer, he will not be changed. Otherwise the issue performer will not be assigned."
   time_tracker_seconds: "seconds"
   time_tracker_settings_from_status: "From status"
   time_tracker_settings_general_title: "General"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,6 @@
 # English strings go here for Rails i18n
 en:
+  auto_change_issue_assigned_to_id: "Fail to change assigned user to the issue"
   list_time_trackers: "list"
   no_time_tracker: "No time tracker"
   no_time_tracker_running: "No time tracker is running"
@@ -42,4 +43,3 @@ en:
   time_tracker_settings_unknown_status: "Unknown status"
   time_tracker_settings_zombie_transition: "zombie status transition"
   time_tracker_zombie_legend: "zombie time tracker"
-

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,5 +1,7 @@
 # Russian strings go here for Rails i18n
 ru:
+  auto_change_issue_assigned_to_id: "Неудалось назначить исполнителя задачи"
+  auto_change_already_issue_assigned_to_id: "У задачи уже есть исполнитель"
   list_time_trackers: "Список таймеров"
   no_time_tracker: "Нет учета времени"
   no_time_tracker_running: "Ни один таймер не запущен"
@@ -27,6 +29,8 @@ ru:
   time_tracker_refresh_rate: "Частота обновления"
   time_tracker_redirect_to_issue: "Редирект в задачу"
   time_tracker_redirect_to_issue_help: "Если этот параметр включен, кнопка остановки трекинга откроет на редактирование задачу. В противном случае открывается только создание трудозатрат."
+  settings_label_issue_assigned_to_id: "Назначать исполнителя"
+  settings_label_issue_assigned_to_id_help: "Если этот параметр включен и при запуске учета времени у задачи нет назначенного исполнителя, то исполнителем этой задачи становится пользователь, который запустил трекер. Если у задачи уже был исполнитель - ответственный не изменяется. Если этот параметр выключен автоматического назначения исполнителя не происходит."
   time_tracker_seconds: "секунды"
   time_tracker_settings_from_status: "Начальный статус"
   time_tracker_settings_general_title: "Основные"

--- a/init.rb
+++ b/init.rb
@@ -15,6 +15,7 @@ Redmine::Plugin.register :redmine_time_tracker do
     settings :default => {
         'refresh_rate' => '60',
         'redirect_to_issue' => 'true',
+        'issue_assigned_to_id' => 'false',
         'status_transitions' => { '5' => '2', '1' => '2', '3' => '2' }
       },
       :partial => 'settings/time_tracker'


### PR DESCRIPTION
Add new property "Assign performer". If it is enabled in the settings and the issue does not have a performer, the issue performer will be assigned current user. If the issue has a performer, he will not be changed. Otherwise the issue performer will not be assigned.